### PR TITLE
Feature: Add Chapter 8 - Extra Markup Structure

### DIFF
--- a/extramarkup.html
+++ b/extramarkup.html
@@ -31,5 +31,6 @@
                 q=charing+cross+road+london&amp;output=embed">
             </iframe>
         </div>
+        <p>&copy; The Art Bookshop</p>
     </body> 
 </html>

--- a/extramarkup.html
+++ b/extramarkup.html
@@ -23,7 +23,7 @@
       <p>Charing Cross Road, London, WC2, UK</p>
       <p>
         <span class="contact">Telephone</span>
-        0207 946 0946
+        <a href="tel:02079460946">0207 946 0946</a>
       </p>
       <p>
         <span class="contact">Email</span>

--- a/extramarkup.html
+++ b/extramarkup.html
@@ -1,36 +1,47 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-    <head>
-        <meta name="description" content="Telephone, email 
-        and directions for The Art Bookshop, London, UK" /> 
-        <title>Contact The Art Bookshop, London UK</title> 
-    </head> 
-    <body> 
-        <div id="header"> 
-            <h1>The Art Book Shop</h1> 
-            <ul> 
-                <li><a href="index.html">home</a></li> 
-                <li><a href="index.html">new publications</a></li> 
-                <li class="current-page">
-                    <a href="index.html">contact</a></li> 
-            </ul> 
-        </div>
-        <div id="content"> 
-            <p>Charing Cross Road, London, WC2, UK</p> 
-            <p><span class="contact">Telephone</span> 
-                0207 946 0946
-            </p>
-            <p><span class="contact">Email</span> 
-            <a href="mailto:books@example.com">
-                books@example.com</a>
-            </p>
-            <iframe width="425" height="275" frameborder="0" 
-                scrolling="no" marginheight="0" marginwidth="0" 
-                src="http://maps.google.co.uk/maps?f=q&amp;
+  <head>
+    <meta
+      name="description"
+      content="Telephone, email 
+        and directions for The Art Bookshop, London, UK"
+    />
+    <title>Contact The Art Bookshop, London UK</title>
+  </head>
+  <body>
+    <div id="header">
+      <h1>The Art Book Shop</h1>
+      <ul>
+        <li><a href="index.html">home</a></li>
+        <li><a href="index.html">new publications</a></li>
+        <li class="current-page">
+          <a href="index.html">contact</a>
+        </li>
+      </ul>
+    </div>
+    <div id="content">
+      <p>Charing Cross Road, London, WC2, UK</p>
+      <p>
+        <span class="contact">Telephone</span>
+        0207 946 0946
+      </p>
+      <p>
+        <span class="contact">Email</span>
+        <a href="mailto:books@example.com"> books@example.com</a>
+      </p>
+      <iframe
+        width="425"
+        height="275"
+        frameborder="0"
+        scrolling="no"
+        marginheight="0"
+        marginwidth="0"
+        src="http://maps.google.co.uk/maps?f=q&amp;
                 source=s_q&amp;hl=en&amp;geocode=&amp;
-                q=charing+cross+road+london&amp;output=embed">
-            </iframe>
-        </div>
-        <p>&copy; The Art Bookshop</p>
-    </body> 
+                q=charing+cross+road+london&amp;output=embed"
+      >
+      </iframe>
+    </div>
+    <p>&copy; The Art Bookshop</p>
+  </body>
 </html>

--- a/extramarkup.html
+++ b/extramarkup.html
@@ -20,10 +20,12 @@
         <div id="content"> 
             <p>Charing Cross Road, London, WC2, UK</p> 
             <p><span class="contact">Telephone</span> 
-            0207 946 0946</p>
+                0207 946 0946
+            </p>
             <p><span class="contact">Email</span> 
             <a href="mailto:books@example.com">
-            books@example.com</a></p>
+                books@example.com</a>
+            </p>
             <iframe width="425" height="275" frameborder="0" 
                 scrolling="no" marginheight="0" marginwidth="0" 
                 src="http://maps.google.co.uk/maps?f=q&amp;

--- a/extramarkup.html
+++ b/extramarkup.html
@@ -24,6 +24,12 @@
             <p><span class="contact">Email</span> 
             <a href="mailto:books@example.com">
             books@example.com</a></p>
+            <iframe width="425" height="275" frameborder="0" 
+                scrolling="no" marginheight="0" marginwidth="0" 
+                src="http://maps.google.co.uk/maps?f=q&amp;
+                source=s_q&amp;hl=en&amp;geocode=&amp;
+                q=charing+cross+road+london&amp;output=embed">
+            </iframe>
         </div>
     </body> 
 </html>

--- a/extramarkup.html
+++ b/extramarkup.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html PUBLIC
+    "-//W3C//DTD HTML 4.01 Transitional//EN"
+    "http://www.w3.org/TR/html4/loose.dtd">
+<html> 
+    <head>
+    </head> 
+    <body> 
+    </body> 
+</html>

--- a/extramarkup.html
+++ b/extramarkup.html
@@ -3,6 +3,9 @@
     "http://www.w3.org/TR/html4/loose.dtd">
 <html> 
     <head>
+        <meta name="description" content="Telephone, email 
+        and directions for The Art Bookshop, London, UK" /> 
+        <title>Contact The Art Bookshop, London UK</title> 
     </head> 
     <body> 
     </body> 

--- a/extramarkup.html
+++ b/extramarkup.html
@@ -1,7 +1,5 @@
-<!DOCTYPE html PUBLIC
-    "-//W3C//DTD HTML 4.01 Transitional//EN"
-    "http://www.w3.org/TR/html4/loose.dtd">
-<html> 
+<!DOCTYPE html>
+<html lang="en">
     <head>
         <meta name="description" content="Telephone, email 
         and directions for The Art Bookshop, London, UK" /> 

--- a/extramarkup.html
+++ b/extramarkup.html
@@ -8,5 +8,22 @@
         <title>Contact The Art Bookshop, London UK</title> 
     </head> 
     <body> 
+        <div id="header"> 
+            <h1>The Art Book Shop</h1> 
+            <ul> 
+                <li><a href="index.html">home</a></li> 
+                <li><a href="index.html">new publications</a></li> 
+                <li class="current-page">
+                    <a href="index.html">contact</a></li> 
+            </ul> 
+        </div>
+        <div id="content"> 
+            <p>Charing Cross Road, London, WC2, UK</p> 
+            <p><span class="contact">Telephone</span> 
+            0207 946 0946</p>
+            <p><span class="contact">Email</span> 
+            <a href="mailto:books@example.com">
+            books@example.com</a></p>
+        </div>
     </body> 
 </html>


### PR DESCRIPTION
#22 Chapter 8 - Extra Markup
This PR introduces `extramarkup.html` to practice additional HTML structural and semantic elements.

- Add HTML 4.01 Transitional `DOCTYPE` declaration
- Add `meta` description for page information
- Implement structured layout using `div` elements (`#header` & `#content`)
- Add navigation menu using `ul` and `li`
- Use `id` and `class` attributes (e.g. `current-page`, `contact`)
- Add contact information (address, telephone, email)
- Implement inline elements using `span`
- Embed Google Maps using `iframe`
- Add `copyright` section using HTML entity